### PR TITLE
2FA input issue

### DIFF
--- a/gitfive/lib/objects.py
+++ b/gitfive/lib/objects.py
@@ -303,7 +303,7 @@ class Credentials():
                 self.save_creds()   # We need to save the _device_id, otherwise, if user provide wrong OTP code,
                                     # it exits and at next login, Github will say that the credentials are wrong,
                                     # unless we provide the same device_id that initiated 2FA procedure.
-                req = await self._as_client.get("https://github.com/sessions/two-factor")
+                req = await self._as_client.get("https://github.com/sessions/two-factor/app", follow_redirects=True)
                 body = bs(req.text, 'html.parser')
                 authenticity_token = body.find("form", {"action": "/sessions/two-factor"}).find("input", {"name": "authenticity_token"}).attrs["value"]
                 msg = body.find("form", {"action": "/sessions/two-factor"}).find("div", {"class": "mt-3"}).text.strip().split("\n")[0]


### PR DESCRIPTION
Encountered 2FA issue. Exception `gitfive login` command:

Traceback (most recent call last):
File "C:\Python310\lib\runpy.py", line 196, in _run_module_as_main
return _run_code(code, main_globals, None,
File "C:\Python310\lib\runpy.py", line 86, in run_code
exec(code, run_globals)
File "c:\users\main\.local\bin\gitfive.exe_main.py", line 7, in <module>
sys.exit(main())
File "C:\Users\main\.local\pipx\venvs\gitfive\lib\site-packages\gitfive\gitfive.py", line 15, in main
parse_args()
File "C:\Users\main\.local\pipx\venvs\gitfive\lib\site-packages\gitfive\lib\cli.py", line 46, in parse_args
trio.run(login_mod.check_and_login, args.clean)
File "C:\Users\main\.local\pipx\venvs\gitfive\lib\site-packages\trio_core_run.py", line 1946, in run
raise runner.main_task_outcome.error
File "C:\Users\main\.local\pipx\venvs\gitfive\lib\site-packages\gitfive\modules\login_mod.py", line 37, in check_and_login
await creds.login()
File "C:\Users\main\.local\pipx\venvs\gitfive\lib\site-packages\gitfive\lib\objects.py", line 276, in login
authenticity_token = body.find("form", {"action": "/sessions/two-factor"}).find("input", {"name": "authenticity_token"}).attrs["value"]
AttributeError: 'NoneType' object has no attribute 'find'


GitHub 2FA endpoint is '/two-factor/app'. GiveFive unable to find attributes.