### PR TITLE
Update GitFive to reflect the changes in Github web pages and forms that broke several features

### DIFF
--- a/gitfive/lib/utils.py
+++ b/gitfive/lib/utils.py
@@ -7,6 +7,7 @@ from PIL import Image
 from unidecode import unidecode
 
 import os
+import re
 import stat
 import socket
 from pathlib import Path
@@ -108,7 +109,8 @@ async def get_commits_count(runner: GitfiveRunner, repo_url: str="", raw_body: s
         req = await runner.as_client.get(repo_url)
         raw_body = req.text
     body = BeautifulSoup(raw_body, 'html.parser')
-    commits_icon_el = body.find("svg", {"class": "octicon-history"})
+    # Slightly modified this line to find the correct <span> containing the commit count
+    commits_icon_el = body.find("a", {"href": re.compile(r'.*/commits/mirage$')})
     if not commits_icon_el:
         return False, 0
     nb_commits_el = commits_icon_el.findNext("span")


### PR DESCRIPTION
Github recently updated some of its web forms / web page layouts, which broke several GitFive features. More specifically, GitFive was not able to create any repository anymore since the repository creation form was modified. The following error was returned by Gitfive:
"Couldn't find the form to create the repo "GitFive-*"".

Similarily, the page layout of the repositories slightly changed, which broke the function in charge of counting the number of commits.

Slight changes were made in this commit that adapt GitFive to these Github interface changes, and make it work again as intended.