### PR TITLE
xray.py -> Add KeyError handling

### DIFF
--- a/gitfive/lib/xray.py
+++ b/gitfive/lib/xray.py
@@ -359,4 +359,8 @@ async def analyze_ext_contribs(runner: GitfiveRunner):
                     if not name in runner.target.usernames_history[username]["names"]:
                         runner.target._add_name(name) # Previous names are valid informations (unless target spoof it)
                         runner.target.usernames_history[username]["names"][name] = {"repos": set()}
-                    runner.target.usernames_history[username]["names"][name]["repos"].add(repo_name)
+
+                    try:
+                        runner.target.usernames_history[username]["names"][name]["repos"].add(repo_name)
+                    except KeyError as e: # Seems to fail on certain names? Was not able to reproduce bug, however it is failing on a specific user.
+                        continue


### PR DESCRIPTION
Seems like GitFive is failing on a specific user due to a KeyError issue, I wasn't able to reproduce the bug on my own profile however so I am not sure what is making it happen... Adding a exception handler as a just in case.