### PR TITLE
Odd KeyError bug fix

### DIFF
--- a/gitfive/lib/xray.py
+++ b/gitfive/lib/xray.py
@@ -74,8 +74,8 @@ def get_repo(token: str, target_username: str, target_id: int, repos_folder: Pat
                     # if username.lower() != target_username.lower(): # => https://github.com/mxrch/GitFive/issues/16
                     if not username in results["usernames_history"]:
                         results["usernames_history"][username] = {"names": {}}
+                    name = unicode_patch(entity.name)
                     if not entity.name in results["usernames_history"][username]["names"]:
-                        name = unicode_patch(entity.name)
                         results["usernames_history"][username]["names"][name] = {"repos": set()}
                     results["usernames_history"][username]["names"][name]["repos"].add(repo_id)
 


### PR DESCRIPTION
For whatever reason - a single character name made the entire script throw a KeyError, and it was fixed by just moving the unicode_patch outside the if-statement

```
concurrent.futures.process._RemoteTraceback:
"""
Traceback (most recent call last):
  File "C:\Program Files\Python311\Lib\concurrent\futures\process.py", line 261, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python311\Lib\site-packages\gitfive\lib\xray.py", line 83, in get_repo
    results["usernames_history"][username]["names"][name]["repos"].add(repo_id)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'R'
"""
```